### PR TITLE
Allow empty string input on vote inputs

### DIFF
--- a/src/components/inputs.js
+++ b/src/components/inputs.js
@@ -43,15 +43,6 @@ export const Inputs = ({ year, setSeats }) => {
       [event.target.name]: value
     })
   }
-  const handleVoteFocus = event => {
-    let { value } = event.target
-    if (value === '0') {
-      setVotes({
-        ...currentVotes,
-        [event.target.name]: ''
-      })
-    }
-  }
   return (
     <>
       <Grid container direction={'column'} alignItems='center'>
@@ -109,9 +100,8 @@ export const Inputs = ({ year, setSeats }) => {
                   size='small'
                   label={`${formatName(party)}`}
                   name={party}
-                  value={currentVotes[party]}
+                  value={currentVotes[party] || ''}
                   onChange={handleVotesChange}
-                  onFocus={handleVoteFocus}
                 />
               </Grid>
               <Grid item xs={6}>


### PR DESCRIPTION
I noticed that when I entered a number into the votes then tried to delete it, It kept a 0 at all times.

I've updated this to handle empty inputs the same way as you do with the electoral votes. 

I believe this also means you no longer require the `handleVoteFocus()` function.

![Kapture 2020-10-02 at 18 53 29](https://user-images.githubusercontent.com/9244507/94892241-a7d6f500-04e0-11eb-9768-70fe38a971dd.gif)
